### PR TITLE
Adding support for custom replies where it makes sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ First install the gem by running:
     [sudo] gem install cinch-basic_ctcp
 
 Then load it in your bot:
+
     require "cinch"
     require "cinch/plugins/basic_ctcp"
 
@@ -37,4 +38,16 @@ are listed in this option.
     configure do |c|
       # only reply to VERSION and TIME
       c.plugins.options[Cinch::Plugins::BasicCTCP][:commands] = [:version, :time]
+    end
+
+### :reply
+This option is a hash table of custom responses to VERSION, SOURCE,
+and CLIENTINFO.
+
+### Example configuration
+    configure do |c|
+      # send custom CTCP VERSION response
+      c.plugins.options[Cinch::Plugins::BasicCTCP][:reply] = {
+        :version => 'My robot v1.0'
+      }
     end

--- a/lib/cinch/plugins/basic_ctcp.rb
+++ b/lib/cinch/plugins/basic_ctcp.rb
@@ -11,7 +11,7 @@ module Cinch
       ctcp :source
       ctcp :clientinfo
       def ctcp_version(m)
-        m.ctcp_reply "Cinch v#{Cinch::VERSION}" if reply_to_ctcp?(:version)
+        m.ctcp_reply reply(:version) || "Cinch v#{Cinch::VERSION}" if reply_to_ctcp?(:version)
       end
 
       def ctcp_time(m)
@@ -23,16 +23,22 @@ module Cinch
       end
 
       def ctcp_source(m)
-        m.ctcp_reply "http://github.com/cinchrb/cinch" if reply_to_ctcp?(:source)
+        m.ctcp_reply reply(:source) || "http://github.com/cinchrb/cinch" if reply_to_ctcp?(:source)
       end
 
       def ctcp_clientinfo(m)
-        m.ctcp_reply "ACTION PING VERSION TIME CLIENTINFO SOURCE" if reply_to_ctcp?(:clientinfo)
+        m.ctcp_reply reply(:clientinfo) || "ACTION PING VERSION TIME CLIENTINFO SOURCE" if reply_to_ctcp?(:clientinfo)
       end
+
+      private
 
       def reply_to_ctcp?(command)
         commands = config[:commands]
         commands.nil? || commands.include?(command)
+      end
+
+      def reply(command)
+        config[:reply][command]
       end
     end
   end


### PR DESCRIPTION
This patch allows users to redefine the replies sent by VERSION, SOURCE, and CLIENTINFO. I did not add support for custom PING or TIME replies because PING and TIME have a strict definition in the RFC.
